### PR TITLE
Refactor 'dependencies' recipe

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.0'
+version '0.5.1'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -1,22 +1,11 @@
 #
 # Cookbook Name:: cop_nginx
 # Recipe:: dependencies
-#
-
-cache = Chef::Config[:file_cache_path]
-
-remote_file 'download nginx gpg key' do
-    path   "#{cache}/nginx.asc"
-    source 'https://nginx.org/packages/keys/nginx_signing.key'
-    owner  'root'
-    group  'root'
-    mode   0644
-    action :create
-end
 
 # NOTE: nginx.org uses 'rhel' instead of 'redhat' in mainline list
 # rhel/centos and debian/ubuntu might be identical, but rather be safe here
 platform = node['platform'] == 'redhat' ? 'rhel' : node['platform']
+
 case node['platform_family']
 when 'debian'
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -47,24 +47,14 @@ when 'debian'
         action  :nothing
     end
 when 'rhel'
-    file 'install nginx repo' do
-        path    '/etc/yum.repos.d/nginx.repo'
-        content "[nginx]
-name=Nginx
-baseurl=https://nginx.org/packages/mainline/#{platform}/#{node['platform_version'].to_i}/$basearch/
-enabled=1
-gpgcheck=1"
-        user   'root'
-        group  'root'
-        mode   0644
+
+    yum_repository 'nginx' do
+        description "NGINX Repository"
+        baseurl "https://nginx.org/packages/mainline/#{platform}/#{node['platform_version'].to_i}/$basearch/"
+        enabled true
+        gpgcheck true
+        gpgkey "https://nginx.org/keys/nginx_signing.key"
         action :create
-        notifies :run, 'execute[import nginx gpg]', :immediately
     end
 
-    execute 'import nginx gpg' do
-        command "rpm --import #{cache}/nginx.asc"
-        # NOTE: nginx public key id: 7BD9BF62
-        not_if  'rpm -qa gpg-pubkey* | grep 7BD9BF62'
-        action  :nothing
-    end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -7,12 +7,9 @@ describe 'nginx::default' do
     it { should be_installed }
   end
 
-  it 'the NGINX service is enabled' do
-    expect(service('nginx')).to be_enabled
-  end
-
-  it 'the NGINX service is running' do
-    expect(service('nginx')).to be_running
+  describe service('nginx') do
+      it { should be_enabled }
+      it { should be_running }
   end
 
   describe command('nginx -v') do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'nginx::default' do
-  # TODO: test source recipe too
-  # TODO: move this to the package recipe
   describe package('nginx') do
     it { should be_installed }
   end


### PR DESCRIPTION
Refactor 'dependencies' recipe to use Chef repository resources (apt_repository/yum_repository). Additionally refactors test suite for `service` to use modern syntax.