### PR TITLE
block.d

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,9 @@ suites:
                        dhparams: /etc/ssl/certs/dhparams.pem
                    includes:
                        - compression
+                   blocks:
+                       - string_block
+                       - hashed_block
             blocks:
               string_block:
                 content: "# Some nice NGINX code"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,3 +47,8 @@ suites:
             blocks:
               test_block:
                 content: "Some nice NGINX code"
+              hashed_block:
+                content:
+                  - "This"
+                  - "works"
+                  - "too"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,10 +45,10 @@ suites:
                    includes:
                        - compression
             blocks:
-              test_block:
-                content: "Some nice NGINX code"
+              string_block:
+                content: "# Some nice NGINX code"
               hashed_block:
                 content:
-                  - "This"
-                  - "works"
-                  - "too"
+                  - "# This"
+                  - "# works"
+                  - "# too"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,3 +44,6 @@ suites:
                        dhparams: /etc/ssl/certs/dhparams.pem
                    includes:
                        - compression
+            blocks:
+              test_block:
+                content: "Some nice NGINX code"

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ NGINX configuration files.
 
 * `node['nginx']['block_dir']` (string) directory to create blocks, defaults to `/etc/nginx/block.d/`
 * `node['nginx']['blocks']` (hash) configuration files to create
-* `node['nginx']['blocks']['<BLOCK_NAME']` (hash) block to create, filename matches `<BLOCK_NAME>`
-* `node['nginx']['blocks']['<BLOCK_NAME']['content']` (string or array) content of block, can be either single line (string), or multiple lines (array)
+* `node['nginx']['blocks']['<BLOCK_NAME>']` (hash) block to create, filename matches `<BLOCK_NAME>`
+* `node['nginx']['blocks']['<BLOCK_NAME>']['content']` (string or array) content of block, can be either single line (string), or multiple lines (array)
 
 The following configuration will create a file `/etc/nginx/block.d/en_rewrite` with the content `rewrite ^/$ /en/ permanent;`. The vhost configuration shows the method of including this block.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,39 @@ mainline version, currently 1.11
 ## Attributes
 - TODO
 
+#### Blocks
+
+The `node['nginx']['blocks']` attribute allows for the inclusion of arbitrary
+NGINX configuration files.
+
+`node['nginx']['block_dir']` (string) directory to create blocks, defaults to `/etc/nginx/block.d/`
+`node['nginx']['blocks']` (hash) configuration files to create
+`node['nginx']['blocks']['<BLOCK_NAME']` (hash) block to create, filename matches `<BLOCK_NAME>`
+`node['nginx']['blocks']['<BLOCK_NAME']['content']` (string or array) content of block, can be either single line (string), or multiple lines (array)
+
+The following configuration will create a file `/etc/nginx/block.d/en_rewrite` with the content `rewrite ^/$ /en/ permanent;`. The vhost configuration shows the method of including this block.
+
+
+```
+nginx: {
+    blocks: {
+        en_rewrite:{
+            content: "rewrite ^/$ /en/ permanent;"
+        }
+    },
+    vhosts: {
+        'example.com' => {
+            server_name: 'example.com',
+            docroot: '/var/www/example.com/index',
+            includes: %w{
+                compression
+                block.d/en_rewrite
+            }
+        }
+    }
+}
+```
+
 ## Usage
 Here's an example `nginx` role that will install Nginx.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ nginx: {
             docroot: '/var/www/example.com/index',
             includes: %w{
                 compression
-                block.d/en_rewrite
+            },
+            blocks: %w{
+                en_rewrite
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ mainline version, currently 1.11
 The `node['nginx']['blocks']` attribute allows for the inclusion of arbitrary
 NGINX configuration files.
 
-`node['nginx']['block_dir']` (string) directory to create blocks, defaults to `/etc/nginx/block.d/`
-`node['nginx']['blocks']` (hash) configuration files to create
-`node['nginx']['blocks']['<BLOCK_NAME']` (hash) block to create, filename matches `<BLOCK_NAME>`
-`node['nginx']['blocks']['<BLOCK_NAME']['content']` (string or array) content of block, can be either single line (string), or multiple lines (array)
+* `node['nginx']['block_dir']` (string) directory to create blocks, defaults to `/etc/nginx/block.d/`
+* `node['nginx']['blocks']` (hash) configuration files to create
+* `node['nginx']['blocks']['<BLOCK_NAME']` (hash) block to create, filename matches `<BLOCK_NAME>`
+* `node['nginx']['blocks']['<BLOCK_NAME']['content']` (string or array) content of block, can be either single line (string), or multiple lines (array)
 
 The following configuration will create a file `/etc/nginx/block.d/en_rewrite` with the content `rewrite ^/$ /en/ permanent;`. The vhost configuration shows the method of including this block.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following configuration will create a file `/etc/nginx/block.d/en_rewrite` w
 ```
 nginx: {
     blocks: {
-        en_rewrite:{
+        en_rewrite: {
             content: "rewrite ^/$ /en/ permanent;"
         }
     },

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['nginx'] = {
     'tcp_nodelay'         => 'on',
     'keepalive_timeout'   => 30,
     'vhost_dir'           => '/etc/nginx/conf.d',
+    'block_dir'           => '/etc/nginx/block.d',
     'gzip'                => 'on',
     'gzip_vary'           => 'on',
     'gzip_proxied'        => 'any',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.5.1'
+version '0.6.0'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/recipes/blocks.rb
+++ b/recipes/blocks.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: cop_nginx
+# Recipe:: blocks
+# Author:: Copious Inc. <engineering@copiousinc.com>
+#
+
+blocks = node['nginx']['blocks']
+
+unless blocks
+    return
+end
+
+directory node['nginx']['block_dir'] do
+    owner 'root'
+    group 'root'
+    mode  0755
+end
+
+blocks.each do |block, data|
+    template "Creating block: #{block}" do 
+        path    "#{node['nginx']['block_dir']}/#{block}"
+        source  'nginx/blocks.erb'
+        owner   'root'
+        group   'root'
+        mode    0644
+        action  :create
+        variables ({
+            'content': data['content']
+        })
+        notifies :restart, 'service[nginx]', :delayed
+    end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,3 +28,4 @@
 include_recipe 'cop_nginx::dependencies'
 include_recipe 'cop_nginx::install'
 include_recipe 'cop_nginx::configure'
+include_recipe 'cop_nginx::blocks'

--- a/templates/nginx/blocks.erb
+++ b/templates/nginx/blocks.erb
@@ -1,3 +1,5 @@
+# Chef generated file. Do not edit.
+
 <% if @content %>
 <% if @content.respond_to? :each %><% @content.each do |line| %><%= line %>
 <% end %>

--- a/templates/nginx/blocks.erb
+++ b/templates/nginx/blocks.erb
@@ -1,0 +1,7 @@
+<% if @content %>
+<% if @content.respond_to? :each %><% @content.each do |line| %><%= line %>
+<% end %>
+<% else %>
+<%= @content %>
+<% end %>
+<% end %>

--- a/templates/nginx/vhost.conf.erb
+++ b/templates/nginx/vhost.conf.erb
@@ -30,4 +30,10 @@ server {
     include <%= file %>;
     <% end %>
 <% end %>
+
+<% if @data['blocks'] %>
+    <% @data['blocks'].each do |block| %>
+    include <%= node['nginx']['block_dir'] %>/<%= block %>;
+    <% end %>
+<% end %>
 }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -56,4 +56,11 @@ describe 'nginx::default' do
     it { should be_mode '644' }
     it { should contain('Some nice NGINX code') }
   end
+
+  describe file('/etc/nginx/block.d/hashed_block') do
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
+    it { should contain("# This\n# works\n# too") }
+  end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -50,7 +50,7 @@ describe 'nginx::default' do
     it { should be_mode '755' }
   end
 
-  describe file('/etc/nginx/block.d/test_block') do
+  describe file('/etc/nginx/block.d/string_block') do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode '644' }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -50,10 +50,10 @@ describe 'nginx::default' do
     it { should be_mode '755' }
   end
 
-
   describe file('/etc/nginx/block.d/test_block') do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode '644' }
+    it { should contain('Some nice NGINX code') }
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -42,4 +42,18 @@ describe 'nginx::default' do
     it { should be_grouped_into 'root' }
     it { should be_mode '644' }
   end
+
+  describe file('/etc/nginx/block.d') do
+    it { should be_directory }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '755' }
+  end
+
+
+  describe file('/etc/nginx/block.d/test_block') do
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
+  end
 end


### PR DESCRIPTION
Creates a new directory `/etc/nginx/block.d/` which can include arbitrary 'blocks' generated by a Chef template. Blocks can be as simple as a single line or multiple lines can be produced using a hash. These blocks can then be used in an `include block.d/{BLOCK}` statement within an NGINX configuration to allow for arbitrary customization. Includes additional Kitchen tests. All Kitchen tests pass.