### PR TITLE
Varnish vhost template/config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -55,3 +55,36 @@ suites:
                   - "# This"
                   - "# works"
                   - "# too"
+  - name: varnish
+    run_list:
+    - recipe[cop_tls::dhparams]
+    - recipe[cop_tls::snakeoil]
+    - recipe[cop_ntp::default]
+    - recipe[cop_base::default]
+    - recipe[cop_varnish::default]
+    - recipe[cop_nginx::default]
+    attributes:
+        tls:
+            snakeoil:
+                certs:
+                    varnish.localhost.com:
+                        country: US
+                        state: Oregon
+                        city: Portland
+                        company: Copious
+                        section: Varnish
+                        hostname: varnish.localhost.com
+                        contact: varnish@copiousdev.com
+        nginx:
+            remove_default_site: true
+            vhosts:
+               varnish.localhost.com:
+                   server_name: varnish.localhost.com
+                   docroot: /var/www/html/testing
+                   ssl:
+                       cert: /etc/ssl/certs/varnish.localhost.com.crt
+                       key: /etc/ssl/private/varnish.localhost.com.key
+                       dhparams: /etc/ssl/certs/dhparams.pem
+        varnish:
+          frontend:
+            port: 6081

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -57,10 +57,10 @@ suites:
                   - "# too"
   - name: varnish
     run_list:
+    - recipe[cop_base::default]
+    - recipe[cop_ntp::default]
     - recipe[cop_tls::dhparams]
     - recipe[cop_tls::snakeoil]
-    - recipe[cop_ntp::default]
-    - recipe[cop_base::default]
     - recipe[cop_varnish::default]
     - recipe[cop_nginx::default]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 
+cookbook 'cop_ntp', git: 'git@github.com:copious-cookbooks/ntp.git'
+cookbook 'cop_base', git: 'git@github.com:copious-cookbooks/base.git'
 cookbook 'cop_tls', git: 'git@github.com:copious-cookbooks/tls.git'
+cookbook 'cop_varnish', git: 'git@github.com:copious-cookbooks/varnish.git'

--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'cop_ntp', git: 'git@github.com:copious-cookbooks/ntp.git'
 cookbook 'cop_base', git: 'git@github.com:copious-cookbooks/base.git'
+cookbook 'cop_ntp', git: 'git@github.com:copious-cookbooks/ntp.git'
 cookbook 'cop_tls', git: 'git@github.com:copious-cookbooks/tls.git'
 cookbook 'cop_varnish', git: 'git@github.com:copious-cookbooks/varnish.git'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.6.0'
+version '0.7.0'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -39,11 +39,20 @@ template 'installing master nginx config' do
     notifies :restart, 'service[nginx]', :delayed
 end
 
+# Check if cop_varnish cookbook is being used
+if node.recipe?('cop_varnish::default')
+    # Varnish specific vhost template
+    vhost_template_source = 'nginx/varnish.conf.erb'
+else
+    # Standard vhost template
+    vhost_template_source = 'nginx/vhost.conf.erb'
+end
+
 if node['nginx']['vhosts']
     node['nginx']['vhosts'].each do |vhost, data|
         template "installing #{vhost} nginx vhost" do
             path     "#{node['nginx']['vhost_dir']}/#{vhost}.conf"
-            source   'nginx/vhost.conf.erb'
+            source   vhost_template_source
             group    'root'
             owner    'root'
             mode     0644

--- a/templates/nginx/varnish.conf.erb
+++ b/templates/nginx/varnish.conf.erb
@@ -1,0 +1,56 @@
+server {
+    listen 80;
+    server_name <%= @data['server_name'] %> <%= @data['additional_names'] %>;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name <%= @data['server_name'] %> <%= @data['additional_names'] %>;
+
+<% if @data['ssl'] %>
+    ssl_certificate           <%= @data['ssl']['cert'] %>;
+    ssl_certificate_key       <%= @data['ssl']['key'] %>;
+    ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
+    ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES;
+    ssl_session_cache         shared:SSL:1m;
+    ssl_session_timeout       30m;
+    ssl_prefer_server_ciphers on;
+<% end %>
+
+    location / {
+        proxy_pass http://<%= node['varnish']['frontend']['ip'] %>:<%= node['varnish']['frontend']['port'] %>;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+
+        proxy_redirect off;
+    }
+}
+
+server {
+    listen <%= node['varnish']['backend']['port'] %>;
+    server_name <%= @data['server_name'] %> <%= @data['additional_names'] %>;
+
+    access_log /var/log/nginx/<%= @data['server_name'] %>.access.log;
+    error_log  /var/log/nginx/<%= @data['server_name'] %>.error.log;
+
+    set $MAGE_ROOT <%= @data['docroot'] %>;
+    root $MAGE_ROOT;
+
+<% if @data['includes'] %>
+    <% @data['includes'].each do |file| %>
+    include <%= file %>;
+    <% end %>
+<% end %>
+
+<% if @data['blocks'] %>
+    <% @data['blocks'].each do |block| %>
+    include <%= node['nginx']['block_dir'] %>/<%= block %>;
+    <% end %>
+<% end %>
+}

--- a/test/integration/varnish/serverspec/default_spec.rb
+++ b/test/integration/varnish/serverspec/default_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'nginx::default' do
+    describe package('nginx') do
+        it { should be_installed }
+    end
+  
+    describe service('nginx') do
+        it { should be_enabled }
+        it { should be_running }
+    end
+  
+    describe port(80) do
+        it { should be_listening }
+    end
+
+    describe port(443) do
+        it { should be_listening }
+    end
+
+    describe port(8080) do
+        it { should be_listening }
+    end
+end
+
+describe 'nginx::varnish' do
+    describe service('varnish') do
+        it { should be_enabled }
+        it { should be_running }
+    end
+
+    describe port(6081) do
+        it { should be_listening }
+    end
+
+    describe file('/etc/nginx/conf.d/varnish.localhost.com.conf') do
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+        it { should be_mode '644' }
+        it { should contain('proxy_pass http://127.0.0.1:6081;') }
+        it { should contain('listen 8080') }
+    end
+end


### PR DESCRIPTION
* Adds cop_varnish and dependencies to Berksfile
* Includes additional Kitchen test suite, 'varnish', with Varnish specific tests
* Creates Varnish and SSL/TLS compatible vhost config template
* Includes logic to use Varnish vhost template if 'cop_varnish' recipe is called
* Bumps metadata to 0.7.0

Varnish vhost terminates SSL/TLS before passing to Varnish cache, then application backend
http request -> upgrade to https -> terminate ssl -> varnish cache -> application