### PR TITLE
SSL ciphers as attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,10 +42,6 @@ suites:
                        cert: /etc/ssl/certs/test.localhost.com.crt
                        key: /etc/ssl/private/test.localhost.com.key
                        dhparams: /etc/ssl/certs/dhparams.pem
-                       additional_ciphers: [
-                           "NEW-CIPHER",
-                           "!BAD-CIPHER"
-                       ]
                    includes:
                        - compression
                    blocks:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,6 +42,10 @@ suites:
                        cert: /etc/ssl/certs/test.localhost.com.crt
                        key: /etc/ssl/private/test.localhost.com.key
                        dhparams: /etc/ssl/certs/dhparams.pem
+                       additional_ciphers: [
+                           "NEW-CIPHER",
+                           "!BAD-CIPHER"
+                       ]
                    includes:
                        - compression
                    blocks:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,19 @@ default['nginx'] = {
         application/xml
         application/xml+rss
         image/svg+xml
+    },
+    'ssl' => {
+        'ciphers' => %w{
+            HIGH
+            !aNULL
+            !eNULL
+            !EXPORT
+            !DES
+            !MD5
+            !PSK
+            !RC4
+            !3DES
+        }
     }
 }
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.7.0'
+version '0.8.0'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/templates/nginx/varnish.conf.erb
+++ b/templates/nginx/varnish.conf.erb
@@ -13,7 +13,7 @@ server {
     ssl_certificate_key       <%= @data['ssl']['key'] %>;
     ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %><%= cipher %>:<% end %>;
+    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %><%= cipher %>:<% end %>; <%# TODO: Logic to remove trailing colon after last cipher %>
     ssl_session_cache         shared:SSL:1m;
     ssl_session_timeout       30m;
     ssl_prefer_server_ciphers on;

--- a/templates/nginx/varnish.conf.erb
+++ b/templates/nginx/varnish.conf.erb
@@ -13,7 +13,7 @@ server {
     ssl_certificate_key       <%= @data['ssl']['key'] %>;
     ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES;
+    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %><%= cipher %>:<% end %>;
     ssl_session_cache         shared:SSL:1m;
     ssl_session_timeout       30m;
     ssl_prefer_server_ciphers on;

--- a/templates/nginx/vhost.conf.erb
+++ b/templates/nginx/vhost.conf.erb
@@ -16,7 +16,7 @@ server {
     ssl_certificate_key       <%= @data['ssl']['key'] %>;
     ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %>:<%= cipher %><% end %>;
+    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %><%= cipher %>:<% end %>;
     ssl_session_cache         shared:SSL:1m;
     ssl_session_timeout       30m;
     ssl_prefer_server_ciphers on;

--- a/templates/nginx/vhost.conf.erb
+++ b/templates/nginx/vhost.conf.erb
@@ -16,7 +16,7 @@ server {
     ssl_certificate_key       <%= @data['ssl']['key'] %>;
     ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES<% if @data['ssl']['additional_ciphers'] %><% @data['ssl']['additional_ciphers'].each do |cipher| %>:<%= cipher %><% end %><% end %>;
+    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %>:<%= cipher %><% end %>;
     ssl_session_cache         shared:SSL:1m;
     ssl_session_timeout       30m;
     ssl_prefer_server_ciphers on;

--- a/templates/nginx/vhost.conf.erb
+++ b/templates/nginx/vhost.conf.erb
@@ -16,7 +16,7 @@ server {
     ssl_certificate_key       <%= @data['ssl']['key'] %>;
     ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES;
+    ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES<% if @data['ssl']['additional_ciphers'] %><% @data['ssl']['additional_ciphers'].each do |cipher| %>:<%= cipher %><% end %><% end %>;
     ssl_session_cache         shared:SSL:1m;
     ssl_session_timeout       30m;
     ssl_prefer_server_ciphers on;

--- a/templates/nginx/vhost.conf.erb
+++ b/templates/nginx/vhost.conf.erb
@@ -16,7 +16,7 @@ server {
     ssl_certificate_key       <%= @data['ssl']['key'] %>;
     ssl_dhparam               <%= @data['ssl']['dhparams'] %>;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %><%= cipher %>:<% end %>;
+    ssl_ciphers               <% node['nginx']['ssl']['ciphers'].each do |cipher| %><%= cipher %>:<% end %>; <%# TODO: Logic to remove trailing colon after last cipher %>
     ssl_session_cache         shared:SSL:1m;
     ssl_session_timeout       30m;
     ssl_prefer_server_ciphers on;

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -70,6 +70,6 @@ describe 'nginx::vhost' do
         it { should be_owned_by 'root' }
         it { should be_grouped_into 'root' }
         it { should be_mode '644' }
-        its(:content) { should include 'ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES:NEW-CIPHER:!BAD-CIPHER;' }
+        its(:content) { should include 'ssl_ciphers               :HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES;' }
     end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -70,6 +70,6 @@ describe 'nginx::vhost' do
         it { should be_owned_by 'root' }
         it { should be_grouped_into 'root' }
         it { should be_mode '644' }
-        its(:content) { should include 'ssl_ciphers               :HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES;' }
+        its(:content) { should include 'ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES:;' }
     end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -64,3 +64,12 @@ describe 'nginx::default' do
     it { should contain("# This\n# works\n# too") }
   end
 end
+
+describe 'nginx::vhost' do
+    describe file('/etc/nginx/conf.d/test.localhost.com.conf') do
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+        it { should be_mode '644' }
+        its(:content) { should include 'ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4:!3DES:NEW-CIPHER:!BAD-CIPHER;' }
+    end
+end


### PR DESCRIPTION
Breaks down `ssl_ciphers` into an attribute `node['nginx']['ssl']['ciphers']` which is an array of SSL ciphers to allow or disallow at the users discretion.

```
node['nginx']['ssl']['ciphers'] = %w{
    HIGH
    !aNULL
    !eNULL
    !EXPORT
    !DES
    !MD5
    !PSK
    !RC4
    !3DES
}
```

Note that the template includes a vestigial colon after the last cipher as the amount of logic required to eliminate this does not outweigh NGINX being tolerant of the unused character.