### PR TITLE
Feature/no cache

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.8.0'
+version '0.8.1'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/templates/nginx/varnish.conf.erb
+++ b/templates/nginx/varnish.conf.erb
@@ -20,6 +20,12 @@ server {
 <% end %>
 
     location / {
+
+        # add no cache header if query string ?no_cache=1 is set in order to bust varnish cache
+        if ($arg_no_cache = "1") {
+            add_header Set-Cookie "no_cache=1;Domain=<%= @data['server_name'] %>;Path=/;Max-Age=64400";
+        }
+
         proxy_pass http://<%= node['varnish']['frontend']['ip'] %>:<%= node['varnish']['frontend']['port'] %>;
 
         proxy_set_header Host $host;

--- a/templates/nginx/varnish.conf.erb
+++ b/templates/nginx/varnish.conf.erb
@@ -23,7 +23,7 @@ server {
 
         # add no cache header if query string ?no_cache=1 is set in order to bust varnish cache
         if ($arg_no_cache = "1") {
-            add_header Set-Cookie "no_cache=1;Domain=<%= @data['server_name'] %>;Path=/;Max-Age=64400";
+            add_header Set-Cookie "<%= node['varnish']['bypass_cookie'] %>=1;Domain=<%= @data['server_name'] %>;Path=/;Max-Age=64400";
         }
 
         proxy_pass http://<%= node['varnish']['frontend']['ip'] %>:<%= node['varnish']['frontend']['port'] %>;


### PR DESCRIPTION
When a special query string variable is passed, set a cookie in order for Varnish to know not to cache those requests where the cookie is set.