### PR TITLE
Include arbitrary 'load_modules' paths in nginx.conf and additional packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,11 @@ suites:
                         hostname: test.localhost.com
                         contact: test@copiousdev.com
         nginx:
+            packages:
+                - 'nginx-module-geoip'
+            modules:
+                - 'modules/ngx_http_geoip_module.so'
+                - 'modules/ngx_stream_geoip_module.so'
             remove_default_site: true
             vhosts:
                test.localhost.com:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ mainline version, currently 1.11
 
 ## Attributes
 - TODO
+* `node['nginx']['packages']` (hash) additional supporting packages to install
+* `node['nginx']['modules']` (hash) paths to NGINX modules to load
 
 #### Blocks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.8.0'
+version '0.9.0'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -7,3 +7,9 @@
 package 'nginx' do
     action :upgrade
 end
+
+if node['nginx']['packages']
+    package node['nginx']['packages'] do
+        action :upgrade
+    end
+end

--- a/templates/nginx/nginx.conf.erb
+++ b/templates/nginx/nginx.conf.erb
@@ -6,6 +6,12 @@ worker_processes <%= node['nginx']['worker_processes'] %>;
 error_log /var/log/nginx/error.log info;
 pid       /var/run/nginx.pid;
 
+<% if node['nginx']['modules'] %>
+    <% node['nginx']['modules'].each do |module_path| %>
+load_module <%=  module_path %>;
+    <% end %>
+<% end %>
+
 events {
     multi_accept       <%= node['nginx']['multi_accept'] %>;
     worker_connections <%= node['nginx']['worker_connections'] %>;

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -5,6 +5,11 @@ describe 'nginx::default' do
     it { should be_installed }
   end
 
+  # Test for additional packages
+  describe package('nginx-module-geoip') do
+    it { should be_installed }
+  end
+
   describe service('nginx') do
       it { should be_enabled }
       it { should be_running }
@@ -27,6 +32,8 @@ describe 'nginx::default' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode '644' }
+    its(:content) { should include 'load_module modules/ngx_http_geoip_module.so;'}
+    its(:content) { should include 'load_module modules/ngx_stream_geoip_module.so;'}
   end
 
   describe file('/etc/nginx/compression') do


### PR DESCRIPTION
* Includes attribute node['nginx']['modules'] to include `load_modules` paths in nginx.conf
* Includes attribute node['nginx']['packages'] to install arbitrary supporting packages

And tests! And the tests all pass!