### PR TITLE
Disable port_in_redirect for Varnish proxy

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures the NGINX web server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.0'
+version '0.9.1'
 
 source_url 'https://github.com/copious-cookbooks/nginx'
 issues_url 'https://github.com/copious-cookbooks/nginx/issues'

--- a/templates/nginx/varnish.conf.erb
+++ b/templates/nginx/varnish.conf.erb
@@ -42,6 +42,8 @@ server {
     listen <%= node['varnish']['backend']['port'] %>;
     server_name <%= @data['server_name'] %> <%= @data['additional_names'] %>;
 
+    port_in_redirect off;
+
     access_log /var/log/nginx/<%= @data['server_name'] %>.access.log;
     error_log  /var/log/nginx/<%= @data['server_name'] %>.error.log;
 


### PR DESCRIPTION
Fixes a bug where a rewrite or redirect can cause the server port number to show up in the URL.